### PR TITLE
Update method for reading data and add odometry

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,13 @@
   
   <build_depend>roscpp</build_depend>  
   <build_depend>sensor_msgs</build_depend>
-  
+  <build_depend>nav_msgs</build_depend>
+
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>nav_msgs</run_depend>
 
-  
+
   <!-- Maintainer Note:
       The vnccpplib directory is from http://www.vectornav.com/support/downloads
       I removed the version string from the directory name, sanitized file 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <iostream>
+#include <cmath>
 #define PI 3.14159265358979323846  /* pi */
 
 // ROS Libraries
@@ -31,10 +32,11 @@
 #include "sensor_msgs/Imu.h"
 #include "sensor_msgs/MagneticField.h"
 #include "sensor_msgs/NavSatFix.h"
+#include "nav_msgs/Odometry.h"
 #include "sensor_msgs/Temperature.h"
 #include "sensor_msgs/FluidPressure.h"
 
-ros::Publisher pubIMU, pubMag, pubGPS, pubTemp, pubPres;
+ros::Publisher pubIMU, pubMag, pubGPS, pubOdom, pubTemp, pubPres;
 
 //Unused covariances initilized to zero's
 boost::array<double, 9ul> linear_accel_covariance = { };
@@ -44,6 +46,7 @@ XmlRpc::XmlRpcValue rpc_temp;
 
 // Include this header file to get access to VectorNav sensors.
 #include "vn/sensors.h"
+#include "vn/compositedata.h"
 
 using namespace std;
 using namespace vn::math;
@@ -57,6 +60,8 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index);
 std::string frame_id;
 //boolean to use ned or enu frame. Defaults to enu which is data format from sensor.
 bool tf_ned_to_enu;
+vec3d initial_position;
+bool initial_position_set = false;
 
 //Basic loop so we can initilize our covariance parameters above
 boost::array<double, 9ul> setCov(XmlRpc::XmlRpcValue rpc){
@@ -83,6 +88,7 @@ int main(int argc, char *argv[])
     pubIMU = n.advertise<sensor_msgs::Imu>("vectornav/IMU", 1000);
     pubMag = n.advertise<sensor_msgs::MagneticField>("vectornav/Mag", 1000);
     pubGPS = n.advertise<sensor_msgs::NavSatFix>("vectornav/GPS", 1000);
+    pubOdom = n.advertise<nav_msgs::Odometry>("vectornav/Odom", 1000);
     pubTemp = n.advertise<sensor_msgs::Temperature>("vectornav/Temp", 1000);
     pubPres = n.advertise<sensor_msgs::FluidPressure>("vectornav/Pres", 1000);
 
@@ -95,33 +101,31 @@ int main(int argc, char *argv[])
     pn.param<std::string>("frame_id", frame_id, "vectornav");
     pn.param<bool>("tf_ned_to_enu", tf_ned_to_enu, false);
     pn.param<int>("async_output_rate", async_output_rate, 40);
-	pn.param<std::string>("serial_port", SensorPort, "/dev/ttyUSB0");
-	pn.param<int>("serial_baud", SensorBaudrate, 115200);
+    pn.param<std::string>("serial_port", SensorPort, "/dev/ttyUSB0");
+    pn.param<int>("serial_baud", SensorBaudrate, 115200);
 
-	//Call to set covariances
-	if(pn.getParam("linear_accel_covariance",rpc_temp))
+    //Call to set covariances
+    if(pn.getParam("linear_accel_covariance",rpc_temp))
     {
         linear_accel_covariance = setCov(rpc_temp);
-	}
+    }
     if(pn.getParam("angular_vel_covariance",rpc_temp))
     {
         angular_vel_covariance = setCov(rpc_temp);
-	}
+    }
     if(pn.getParam("orientation_covariance",rpc_temp))
     {
         orientation_covariance = setCov(rpc_temp);
     }
 
-		
     ROS_INFO("Connecting to : %s @ %d Baud", SensorPort.c_str(), SensorBaudrate);
 
     // Create a VnSensor object and connect to sensor
     VnSensor vs;
-    
+
     // Default baudrate variable
     int defaultBaudrate;
-
-    // Run through all of the acceptable baud rates until we are connected 
+    // Run through all of the acceptable baud rates until we are connected
     // Looping in case someone has changed the default
     bool baudSet = false;
     while(!baudSet){
@@ -130,35 +134,32 @@ int main(int argc, char *argv[])
         defaultBaudrate = vs.supportedBaudrates()[i];
         ROS_INFO("Connecting with default at %d", defaultBaudrate);
         // Default response was too low and retransmit time was too long by default.
-        // They would cause errors 
-        vs.setResponseTimeoutMs(1000); // Wait for up to 1000 ms for response	
+        // They would cause errors
+        vs.setResponseTimeoutMs(1000); // Wait for up to 1000 ms for response
         vs.setRetransmitDelayMs(50);  // Retransmit every 50 ms
 
         // Acceptable baud rates 9600, 19200, 38400, 57600, 128000, 115200, 230400, 460800, 921600
-        // Data sheet says 128000 is a valid baud rate. It doesn't work with the VN100 so it is excluded. 
+        // Data sheet says 128000 is a valid baud rate. It doesn't work with the VN100 so it is excluded.
         // All other values seem to work fine.
         try{
             // Connect to sensor at it's default rate
             if(defaultBaudrate != 128000 && SensorBaudrate != 128000)
             {
                 vs.connect(SensorPort, defaultBaudrate);
-	            // Issues a change baudrate to the VectorNav sensor and then
-	            // reconnects the attached serial port at the new baudrate.
+                // Issues a change baudrate to the VectorNav sensor and then
+                // reconnects the attached serial port at the new baudrate.
                 vs.changeBaudRate(SensorBaudrate);
-
-                // Only makes it here once we have the default correct 
+                // Only makes it here once we have the default correct
                 ROS_INFO("Connected baud rate is %d",vs.baudrate());
                 baudSet = true;
             }
-
         }
-        // Catch all oddities  
+        // Catch all oddities
         catch(...){
             // Disconnect if we had the wrong default and we were connected
             vs.disconnect();
             ros::Duration(0.2).sleep();
         }
-        
         // Increment the default iterator
         i++;
         // There are only 9 available data rates, if no connection
@@ -168,7 +169,7 @@ int main(int argc, char *argv[])
             break;
         }
     }
-    
+
     // Now we verify connection (Should be good if we made it this far)
     if(vs.verifySensorConnectivity())
     {
@@ -178,34 +179,38 @@ int main(int argc, char *argv[])
         ROS_WARN("Please input a valid baud rate. Valid are:");
         ROS_WARN("9600, 19200, 38400, 57600, 115200, 128000, 230400, 460800, 921600");
         ROS_WARN("With the test IMU 128000 did not work, all others worked fine.");
-    } 
-
+    }
     // Query the sensor's model number.
-    string mn = vs.readModelNumber();	
+    string mn = vs.readModelNumber();
     ROS_INFO("Model Number: %s", mn.c_str());
 
     // Set Data output Freq [Hz]
     vs.writeAsyncDataOutputFrequency(async_output_rate);
-  
-	// Configure binary output message
-	BinaryOutputRegister bor(
-		ASYNCMODE_PORT1,
-		1000 / async_output_rate,  // update rate [ms]
-		COMMONGROUP_TIMESTARTUP 
-        | COMMONGROUP_QUATERNION 
-        | COMMONGROUP_ANGULARRATE 
-        | COMMONGROUP_POSITION 
-        | COMMONGROUP_ACCEL 
-        | COMMONGROUP_MAGPRES,
-		TIMEGROUP_NONE,
-		IMUGROUP_NONE,
-		GPSGROUP_NONE,
-		ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
-		INSGROUP_NONE);
+
+    // Configure binary output message
+    BinaryOutputRegister bor(
+            ASYNCMODE_PORT1,
+            1000 / async_output_rate,  // update rate [ms]
+            COMMONGROUP_QUATERNION
+            | COMMONGROUP_ANGULARRATE
+            | COMMONGROUP_POSITION
+            | COMMONGROUP_ACCEL
+            | COMMONGROUP_MAGPRES,
+            TIMEGROUP_NONE,
+            IMUGROUP_NONE,
+            GPSGROUP_NONE,
+            ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
+            INSGROUP_INSSTATUS
+            | INSGROUP_POSLLA
+            | INSGROUP_POSECEF
+            | INSGROUP_VELBODY
+            | INSGROUP_ACCELECEF);
 
     vs.writeBinaryOutput1(bor);
-    vs.registerAsyncPacketReceivedHandler(NULL, BinaryAsyncMessageReceived);
 
+    // Set Data output Freq [Hz]
+    vs.writeAsyncDataOutputFrequency(async_output_rate);
+    vs.registerAsyncPacketReceivedHandler(NULL, BinaryAsyncMessageReceived);
 
     // You spin me right round, baby
     // Right round like a record, baby
@@ -215,63 +220,33 @@ int main(int argc, char *argv[])
         ros::spin(); // Need to make sure we disconnect properly. Check if all ok.
     }
 
-
     // Node has been terminated
     vs.unregisterAsyncPacketReceivedHandler();
     ros::Duration(0.5).sleep();
     vs.disconnect();
     ros::Duration(0.5).sleep();
-	return 0;
+    return 0;
 }
-
 
 //
 // Callback function to process data packet from sensor
 //
 void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
 {
-	
-    if (p.type() == Packet::TYPE_BINARY)
+    vn::sensors::CompositeData cd = vn::sensors::CompositeData::parse(p);
+
+    // IMU
+    sensor_msgs::Imu msgIMU;
+    msgIMU.header.stamp = ros::Time::now();
+    msgIMU.header.frame_id = frame_id;
+
+    if (cd.hasQuaternion() && cd.hasAngularRate() && cd.hasAcceleration())
     {
-        // First make sure we have a binary packet type we expect since there
-        // are many types of binary output types that can be configured.
-        if (!p.isCompatible(
-			COMMONGROUP_TIMESTARTUP 
-            | COMMONGROUP_QUATERNION 
-            | COMMONGROUP_ANGULARRATE 
-            | COMMONGROUP_POSITION 
-            | COMMONGROUP_ACCEL 
-            | COMMONGROUP_MAGPRES,
-            TIMEGROUP_NONE,
-            IMUGROUP_NONE,
-            GPSGROUP_NONE,
-            ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
-            INSGROUP_NONE))
-            // Not the type of binary packet we are expecting.
-            return;
 
+        vec4f q = cd.quaternion();
+        vec3f ar = cd.angularRate();
+        vec3f al = cd.acceleration();
 
-        // Unpack the packet
-        uint64_t timeStartup = p.extractUint64();
-        vec4f q = p.extractVec4f();
-        vec3f ar = p.extractVec3f();
-        vec3d lla = p.extractVec3d();
-        vec3f al = p.extractVec3f();
-        vec3f mag = p.extractVec3f();
-        float temp = p.extractFloat();
-        float pres = p.extractFloat();
-		
-		//TEST
-		vec3f orientationStdDev = p.extractVec3f();
-		
-        // Publish ROS Message
-		
-        // IMU
-        sensor_msgs::Imu msgIMU;
-		
-        msgIMU.header.stamp = ros::Time::now();
-        msgIMU.header.frame_id = frame_id;
-		
         //Quaternion message comes in as a Yaw (z) Pitch (y) Roll (x) format
         if (tf_ned_to_enu)
         {
@@ -280,15 +255,18 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
             msgIMU.orientation.y = q[0];
             msgIMU.orientation.z = -q[2];
             msgIMU.orientation.w = q[3];
-            msgIMU.orientation_covariance[0] = orientationStdDev[1]*orientationStdDev[1]*PI/180;//Convert to radians Pitch
-            msgIMU.orientation_covariance[4] = orientationStdDev[0]*orientationStdDev[0]*PI/180;//Convert to radians Roll
-            msgIMU.orientation_covariance[8] = orientationStdDev[2]*orientationStdDev[2]*PI/180;//Convert to radians Yaw
 
+            if (cd.hasAttitudeUncertainty())
+            {
+                vec3f orientationStdDev = cd.attitudeUncertainty();
+                msgIMU.orientation_covariance[0] = orientationStdDev[1]*orientationStdDev[1]*PI/180;//Convert to radians Pitch
+                msgIMU.orientation_covariance[4] = orientationStdDev[0]*orientationStdDev[0]*PI/180;//Convert to radians Roll
+                msgIMU.orientation_covariance[8] = orientationStdDev[2]*orientationStdDev[2]*PI/180;//Convert to radians Yaw
+            }
             // Flip x and y then invert z
             msgIMU.angular_velocity.x = ar[1];
             msgIMU.angular_velocity.y = ar[0];
             msgIMU.angular_velocity.z = -ar[2];
-
             // Flip x and y then invert z
             msgIMU.linear_acceleration.x = al[1];
             msgIMU.linear_acceleration.y = al[0];
@@ -300,73 +278,120 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
             msgIMU.orientation.y = q[1];
             msgIMU.orientation.z = q[2];
             msgIMU.orientation.w = q[3];
-            msgIMU.orientation_covariance[0] = orientationStdDev[2]*orientationStdDev[2]*PI/180;//Convert to radians Roll
-            msgIMU.orientation_covariance[4] = orientationStdDev[1]*orientationStdDev[1]*PI/180;//Convert to radians Pitch
-            msgIMU.orientation_covariance[8] = orientationStdDev[0]*orientationStdDev[0]*PI/180;//Convert to radians Yaw
 
+            if (cd.hasAttitudeUncertainty())
+            {
+                vec3f orientationStdDev = cd.attitudeUncertainty();
+                msgIMU.orientation_covariance[0] = orientationStdDev[2]*orientationStdDev[2]*PI/180;//Convert to radians Roll
+                msgIMU.orientation_covariance[4] = orientationStdDev[1]*orientationStdDev[1]*PI/180;//Convert to radians Pitch
+                msgIMU.orientation_covariance[8] = orientationStdDev[0]*orientationStdDev[0]*PI/180;//Convert to radians Yaw
+            }
             msgIMU.angular_velocity.x = ar[0];
             msgIMU.angular_velocity.y = ar[1];
             msgIMU.angular_velocity.z = ar[2];
-
             msgIMU.linear_acceleration.x = al[0];
             msgIMU.linear_acceleration.y = al[1];
             msgIMU.linear_acceleration.z = al[2];
         }
-		
         // Covariances pulled from parameters
-        msgIMU.angular_velocity_covariance = angular_vel_covariance;		
+        msgIMU.angular_velocity_covariance = angular_vel_covariance;
         msgIMU.linear_acceleration_covariance = linear_accel_covariance;
-		
         pubIMU.publish(msgIMU);
+    }
 
-    
-        // Magnetic Field
+    // Magnetic Field
+    if (cd.hasMagnetic())
+    {
+        vec3f mag = cd.magnetic();
         sensor_msgs::MagneticField msgMag;
-    
         msgMag.header.stamp = msgIMU.header.stamp;
         msgMag.header.frame_id = msgIMU.header.frame_id;
-
         msgMag.magnetic_field.x = mag[0];
         msgMag.magnetic_field.y = mag[1];
         msgMag.magnetic_field.z = mag[2];
-
         pubMag.publish(msgMag);
-    
-    
-        // GPS
+    }
+
+    // GPS
+    if (cd.hasInsStatus())
+    {
+        vec3d lla = cd.positionEstimatedLla();
+
         sensor_msgs::NavSatFix msgGPS;
-    
         msgGPS.header.stamp = msgIMU.header.stamp;
         msgGPS.header.frame_id = msgIMU.header.frame_id;
-
         msgGPS.latitude = lla[0];
         msgGPS.longitude = lla[1];
         msgGPS.altitude = lla[2];
-
         pubGPS.publish(msgGPS);
-    
-    
-        // Temperature
+
+        // Odometry
+        nav_msgs::Odometry msgOdom;
+        msgOdom.header.stamp = msgIMU.header.stamp;
+        msgOdom.header.frame_id = msgIMU.header.frame_id;
+        vec3d pos = cd.positionEstimatedEcef();
+
+        if (!initial_position_set)
+        {
+            initial_position_set = true;
+            initial_position.x = pos[0];
+            initial_position.y = pos[1];
+            initial_position.z = pos[2];
+        }
+
+        msgOdom.pose.pose.position.x = pos[0] - initial_position[0];
+        msgOdom.pose.pose.position.y = pos[1] - initial_position[1];
+        msgOdom.pose.pose.position.z = pos[2] - initial_position[2];
+
+        if (cd.hasQuaternion())
+        {
+            vec4f q = cd.quaternion();
+
+            msgOdom.pose.pose.orientation.x = q[0];
+            msgOdom.pose.pose.orientation.y = q[1];
+            msgOdom.pose.pose.orientation.z = q[2];
+            msgOdom.pose.pose.orientation.w = q[2];
+        }
+        if (cd.hasVelocityEstimatedBody())
+        {
+            vec3f vel = cd.velocityEstimatedBody();
+
+            msgOdom.twist.twist.linear.x = vel[0];
+            msgOdom.twist.twist.linear.y = vel[1];
+            msgOdom.twist.twist.linear.z = vel[2];
+        }
+        if (cd.hasAngularRate())
+        {
+            vec3f ar = cd.angularRate();
+
+            msgOdom.twist.twist.angular.x = ar[0];
+            msgOdom.twist.twist.angular.y = ar[1];
+            msgOdom.twist.twist.angular.z = ar[2];
+        }
+        pubOdom.publish(msgOdom);
+    }
+
+    // Temperature
+    if (cd.hasTemperature())
+    {
+        float temp = cd.temperature();
+
         sensor_msgs::Temperature msgTemp;
-    
         msgTemp.header.stamp = msgIMU.header.stamp;
         msgTemp.header.frame_id = msgIMU.header.frame_id;
-    
         msgTemp.temperature = temp;
-    
         pubTemp.publish(msgTemp);
-    
-    
-        // Barometer
+    }
+
+    // Barometer
+    if (cd.hasPressure())
+    {
+        float pres = cd.pressure();
+
         sensor_msgs::FluidPressure msgPres;
-    
         msgPres.header.stamp = msgIMU.header.stamp;
         msgPres.header.frame_id = msgIMU.header.frame_id;
-    
         msgPres.fluid_pressure = pres;
-    
         pubPres.publish(msgPres);
-  
     }
 }
-


### PR DESCRIPTION
Changed the way data is read. Instead of reading from serial data is read using the built-in CompositeData methods.
Added odomtery messages. After getting a lock on INS, the initial position is recorded and all future postions are published relative to the initial position.