### PR TITLE
Feature fix rates

### DIFF
--- a/params/vn100.yaml
+++ b/params/vn100.yaml
@@ -9,6 +9,10 @@ serial_baud: 115200
 # Baud rate must be able to handle the data rate
 async_output_rate: 40
 
+# Device IMU Rate as set by the manufacturer (800Hz unless specified otherwise)
+# This value is used to set the serial data packet rate
+fixed_imu_rate: 800
+
 # Frame id to publish data in
 frame_id: imu_link
 
@@ -31,7 +35,3 @@ angular_vel_covariance: [0.01,  0.0,   0.0,
 orientation_covariance: [0.01,  0.0,   0.0,
                             0.0,   0.01,  0.0,
                             0.0,   0.0,   0.01]
-
-
-
-

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,12 +111,16 @@ int main(int argc, char *argv[])
     int SensorBaudrate;
     int async_output_rate;
 
+    // Sensor IMURATE (800Hz by default, used to configure device)
+    int SensorImuRate;
+
     // Load all params
     pn.param<std::string>("frame_id", frame_id, "vectornav");
     pn.param<bool>("tf_ned_to_enu", tf_ned_to_enu, false);
     pn.param<int>("async_output_rate", async_output_rate, 40);
     pn.param<std::string>("serial_port", SensorPort, "/dev/ttyUSB0");
     pn.param<int>("serial_baud", SensorBaudrate, 115200);
+    pn.param<int>("fixed_imu_rate", SensorImuRate, 800);
 
     //Call to set covariances
     if(pn.getParam("linear_accel_covariance",rpc_temp))
@@ -204,7 +208,7 @@ int main(int argc, char *argv[])
     // Configure binary output message
     BinaryOutputRegister bor(
             ASYNCMODE_PORT1,
-            800 / async_output_rate,  // update rate [ms]
+            SensorImuRate / async_output_rate,  // update rate [ms]
             COMMONGROUP_QUATERNION
             | COMMONGROUP_ANGULARRATE
             | COMMONGROUP_POSITION

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,7 +204,7 @@ int main(int argc, char *argv[])
     // Configure binary output message
     BinaryOutputRegister bor(
             ASYNCMODE_PORT1,
-            1000 / async_output_rate,  // update rate [ms]
+            800 / async_output_rate,  // update rate [ms]
             COMMONGROUP_QUATERNION
             | COMMONGROUP_ANGULARRATE
             | COMMONGROUP_POSITION

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,8 +331,8 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
     }
 
     // GPS
-    //if (cd.insStatus() == INSSTATUS_GPS_FIX)
-    //{
+    if (cd.hasInsStatus() && (cd.insStatus() == INSSTATUS_GPS_FIX))
+    {
         vec3d lla = cd.positionEstimatedLla();
 
         sensor_msgs::NavSatFix msgGPS;
@@ -390,7 +390,7 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
             }
             pubOdom.publish(msgOdom);
         }
-    //}
+    }
 
     // Temperature
     if (cd.hasTemperature())


### PR DESCRIPTION
Fixes #34 

As noted in #34, the `IMURATE` included in the node is not the standard (factory default) 800Hz. This causes the actual ROS publish rates to be lower than expected (by 20%). 

This PR adds a parameter for the `IMURATE` which defaults to 800. It also fixes a bug while running with a VN100 by checking the device family before building the INS/Odom messages. Since a VN100 doesn't produce INS data, this particular message production should never be run.