### PR TITLE
Quaternion/update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
+# Compile options so compiles with ROS Kinetic
+# Future releases may want to 
+add_compile_options(-std=c++11)
 project(vectornav)
 
 ## Find catkin macros and libraries
@@ -6,51 +9,9 @@ project(vectornav)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED roscpp)
 
-## System dependencies are found with CMake's conventions
-#find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-#######################################
-## Declare ROS messages and services ##
-#######################################
-
-# Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   ins.msg
-#   gps.msg
-#   sensors.msg
-#   utc_time.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate added messages and services with any dependencies listed here
-#generate_messages(
-#  DEPENDENCIES
-#  std_msgs 
-#  geometry_msgs
-#)
-
 ###################################
 ## catkin specific configuration ##
 ###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES vectornav
@@ -79,50 +40,9 @@ target_link_libraries(vnpub
   ${catkin_LIBRARIES}
 )
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-# Mark executable scripts (Python etc.) for installation
-
-#install(PROGRAMS
-#  scripts/gpsFix.py
-#  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-#)
-
 ## Mark executables and/or libraries for installation
 install(TARGETS vnpub
    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_vectornav.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/params/vn100.yaml
+++ b/params/vn100.yaml
@@ -19,6 +19,12 @@ frame_id: imu_link
 # Data publication form, true for East North Up or false for North East Down <- false is default setting
 tf_ned_to_enu: false
 
+# If publishing ENU, do we want to publish in the frame labeled on the device? Default is false.
+# If tf_ned_to_enu = true and frame_based_enu = false orientation is reported by: x->y y->x z->-z to rotate the quaternion
+# Proper method is to rotate the quaternion by multiplication
+# If tf_ned_to_enu = true and frame_based_enu = true we rotate the quaternion to the frame matched label by multiplication
+frame_based_enu: false
+
 # Make sure all covariances below are of type xx.xx , i.e. double so that the rpc is parsed correctly
 
 # Linear Acceleration Covariances not produced by the sensor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -304,6 +304,15 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
                 // Apply the NED to ENU rotation such that the coordinate frame matches
                 tf2_quat = q_rotate*tf2_quat;
                 quat_msg = tf2::toMsg(tf2_quat);
+
+                // Since everything is in the normal frame, no flipping required
+                msgIMU.angular_velocity.x = ar[0];
+                msgIMU.angular_velocity.y = ar[1];
+                msgIMU.angular_velocity.z = ar[2];
+
+                msgIMU.linear_acceleration.x = al[0];
+                msgIMU.linear_acceleration.y = al[1];
+                msgIMU.linear_acceleration.z = al[2];
             }
             else
             {


### PR DESCRIPTION
This PR is a Quaternion rotation from NED to ENU by doing a Quaternion multiplication. The previous method was to flip the x&z and invert z. The problem with the previous method is that when defining the TF tree in ROS there is a an underlying guess work to make sure the TF aligns properly. Using the `frame_based_enu` set to `true` you can now just define the TF to what is printed on the Vectornav itself.

Default parameters are exactly as they were so if a user doesn't want this option, they don't even need to worry about it.