### PR TITLE
Fix build deps

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,8 +23,8 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
-  <build_depend>tf2</build_depend>
-  <build_depend>tf2_geometry_msgs</build_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
 
 
   <!-- Maintainer Note:

--- a/package.xml
+++ b/package.xml
@@ -13,19 +13,21 @@
   <author email="dereck@gmail.com">Dereck Wonnacott</author>
 
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <build_depend>roscpp</build_depend>  
+
+  <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>tf2</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <build_depend>tf2</build_depend>
 
 
   <!-- Maintainer Note:
       The vnccpplib directory is from http://www.vectornav.com/support/downloads
-      I removed the version string from the directory name, sanitized file 
+      I removed the version string from the directory name, sanitized file
       permissions, and removed all but the src and include directories.
    -->
 </package>

--- a/package.xml
+++ b/package.xml
@@ -18,11 +18,13 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>tf2</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>nav_msgs</run_depend>
   <build_depend>tf2</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
 
   <!-- Maintainer Note:


### PR DESCRIPTION
I ran across these missing dependencies in the packaging when building from a `ros-base` install. Ultimately they are in the `geometry2` meta-package but only these two are actually needed. This enables a user to install from `ros-base` by using `rosdep`. Some extra spaces were also removed by my editor ... 😅 