### PR TITLE
Install libvncxx

### DIFF
--- a/vnproglib-1.1.4.0/cpp/CMakeLists.txt
+++ b/vnproglib-1.1.4.0/cpp/CMakeLists.txt
@@ -74,6 +74,12 @@ include_directories(
 
 add_library(libvncxx ${SOURCE})
 
+install(TARGETS libvncxx
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
 #add_subdirectory(examples/ez_async_data)
 #add_subdirectory(examples/getting_started)
 #add_subdirectory(examples/math)


### PR DESCRIPTION
Hi @dawonn, we make debian files to install this library (thanks for writing), and noticed that when you run the standard bloom debian helper, it does not install the libvncxx properly to standard `/opt/ros/melodic/lib/vectornav/`

Here's from the system log after installing:
```
Apr 06 12:34:47 [redacted-hostname] [redacted-process][331]: /opt/ros/melodic/lib/vectornav/vnpub: error while loading shared libraries: liblibvncxx.so: cannot open shared object file: No such file or directory
Apr 06 12:34:47 [redacted-hostname] [redacted-process][331]: failed to start local process: /opt/ros/melodic/lib/vectornav/vnpub __name:=vectornav_imu_node __log:=/var/log/plaut/86bc1542-7824-11ea-ae57-6e562e078d3a/vectornav_imu_node-11.log
Apr 06 12:34:47 [redacted-hostname] [redacted-process]: local launch of vectornav/vnpub failed
```

We noticed in #31 that it was updated and that libvncxx was removed.  This "adds it" back into the modified CMakeLists.txt file for the vnproglib and makes sure that the shared object is installed.

The debian now includes the `liblibvncxx.so`  (looks like it prepends lib for us!) and works on a standard debian install.

Any thoughts on this?

cc @alecGraves
