### PR TITLE
On connect, only call readGpsCompassBaseline if on a vn-300

### DIFF
--- a/vectornav/CMakeLists.txt
+++ b/vectornav/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(${PROJECT_NAME} vncxx )
 
 # vn_sensor_msgs
 add_executable(vn_sensor_msgs src/vn_sensor_msgs.cc)
-ament_target_dependencies(vn_sensor_msgs rclcpp sensor_msgs vectornav_msgs)
+ament_target_dependencies(vn_sensor_msgs rclcpp sensor_msgs vectornav_msgs tf2_geometry_msgs)
 
 # install
 install(TARGETS

--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -363,14 +363,17 @@ private:
 
     // GPS Compass Baseline
     // 8.2.3
-    auto gps_baseline = vs_.readGpsCompassBaseline();
-    RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
-      gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
-      gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+    try {
+      auto gps_baseline = vs_.readGpsCompassBaseline();
+      RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
+        gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
+        gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
 
+    } catch (vn::sensors::sensor_error e) {
+      RCLCPP_ERROR(get_logger(), "readGpsCompassBaseline: %s", e.what());
+    }
     // Register Binary Data Callback
     vs_.registerAsyncPacketReceivedHandler(this, Vectornav::AsyncPacketReceivedHandler);
-
     // Connection Successful
     return true;
   }

--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -363,14 +363,13 @@ private:
 
     // GPS Compass Baseline
     // 8.2.3
-    try {
+    // According to dawonn, readGpsCompassBaseline is likely only available 
+    // on the VN-300
+    if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
       auto gps_baseline = vs_.readGpsCompassBaseline();
       RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
         gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
         gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
-
-    } catch (vn::sensors::sensor_error e) {
-      RCLCPP_ERROR(get_logger(), "readGpsCompassBaseline: %s", e.what());
     }
     // Register Binary Data Callback
     vs_.registerAsyncPacketReceivedHandler(this, Vectornav::AsyncPacketReceivedHandler);


### PR DESCRIPTION
- Incorporates [PR-59](https://github.com/dawonn/vectornav/pull/59) feedback.
- Addresses [issue-57](https://github.com/dawonn/vectornav/issues/57).