### PR TITLE
Conversion from NED to ENU for Odom message

### DIFF
--- a/params/vn100.yaml
+++ b/params/vn100.yaml
@@ -13,7 +13,10 @@ async_output_rate: 40
 # This value is used to set the serial data packet rate
 fixed_imu_rate: 800
 
-# Frame id to publish data in
+# Frame id where pose of Odom message is specified (used only for Odom header.frame_id)
+map_frame_id: map
+
+# Frame id of the sensor (used for header.frame_id of other messages and for Odom child_frame_id)
 frame_id: imu_link
 
 # Data publication form, true for East North Up or false for North East Down <- false is default setting

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -500,9 +500,16 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
                 {
                     vec3f orientationStdDev = cd.attitudeUncertainty();
                     // convert the standard deviation values from all three axis from degrees to radiant and calculate the variances from these (squared), which are assigned to the covariance matrix.
-                    msgOdom.pose.covariance[21] = pow(orientationStdDev[0] * M_PI / 180, 2);    // roll variance
-                    msgOdom.pose.covariance[28] = pow(orientationStdDev[1] * M_PI / 180, 2);    // pitch variance
-                    msgOdom.pose.covariance[35] = pow(orientationStdDev[2] * M_PI / 180, 2);    // yaw variance
+                    if(!tf_ned_to_enu || frame_based_enu) {
+                        // standard assignment of variance values for NED frame and conversion to ENU frame by rotation
+                        msgOdom.pose.covariance[21] = pow(orientationStdDev[0] * M_PI / 180, 2);    // roll variance
+                        msgOdom.pose.covariance[28] = pow(orientationStdDev[1] * M_PI / 180, 2);    // pitch variance
+                        msgOdom.pose.covariance[35] = pow(orientationStdDev[2] * M_PI / 180, 2);    // yaw variance
+                    } else {
+                        // variance assignment for conversion by swapping and invering (not frame_based_enu)
+
+                        // TODO not supported yet
+                    }
                 }
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,9 @@ using namespace vn::xplat;
 // Method declarations for future use.
 void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index);
 
+// frame id used only for Odom header.frame_id
+std::string map_frame_id;
+// frame id used for header.frame_id of other messages and for Odom child_frame_id
 std::string frame_id;
 // Boolean to use ned or enu frame. Defaults to enu which is data format from sensor.
 bool tf_ned_to_enu;
@@ -125,6 +128,7 @@ int main(int argc, char *argv[])
     int SensorImuRate;
 
     // Load all params
+    pn.param<std::string>("map_frame_id", map_frame_id, "map");
     pn.param<std::string>("frame_id", frame_id, "vectornav");
     pn.param<bool>("tf_ned_to_enu", tf_ned_to_enu, false);
     pn.param<bool>("frame_based_enu", frame_based_enu, false);
@@ -400,7 +404,8 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
         {
             nav_msgs::Odometry msgOdom;
             msgOdom.header.stamp = msgIMU.header.stamp;
-            msgOdom.header.frame_id = msgIMU.header.frame_id;
+            msgOdom.child_frame_id = frame_id;
+            msgOdom.header.frame_id = map_frame_id;
             vec3d pos = cd.positionEstimatedEcef();
 
             if (!initial_position_set)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,8 +305,8 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
         if (cd.hasAttitudeUncertainty())
         {
             vec3f orientationStdDev = cd.attitudeUncertainty();
-            msgIMU.orientation_covariance[0] = pow(orientationStdDev[2]*M_PI/180, 2); // Convert to radians pitch
-            msgIMU.orientation_covariance[4] = pow(orientationStdDev[1]*M_PI/180, 2); // Convert to radians Roll
+            msgIMU.orientation_covariance[0] = pow(orientationStdDev[2]*M_PI/180, 2); // Convert to radians Roll
+            msgIMU.orientation_covariance[4] = pow(orientationStdDev[1]*M_PI/180, 2); // Convert to radians Pitch
             msgIMU.orientation_covariance[8] = pow(orientationStdDev[0]*M_PI/180, 2); // Convert to radians Yaw
         }
 
@@ -500,9 +500,9 @@ void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
                 {
                     vec3f orientationStdDev = cd.attitudeUncertainty();
                     // convert the standard deviation values from all three axis from degrees to radiant and calculate the variances from these (squared), which are assigned to the covariance matrix.
-                    msgOdom.pose.covariance[21] = pow(orientationStdDev[0] * M_PI / 180, 2);    // yaw variance
+                    msgOdom.pose.covariance[21] = pow(orientationStdDev[0] * M_PI / 180, 2);    // roll variance
                     msgOdom.pose.covariance[28] = pow(orientationStdDev[1] * M_PI / 180, 2);    // pitch variance
-                    msgOdom.pose.covariance[35] = pow(orientationStdDev[2] * M_PI / 180, 2);    // roll variance
+                    msgOdom.pose.covariance[35] = pow(orientationStdDev[2] * M_PI / 180, 2);    // yaw variance
                 }
             }
 


### PR DESCRIPTION
The code supports two methods to change the coordinate frame. The method can by selected with the frame_based_enu parameter. This is equivalent to IMU message.