### PR TITLE
Refactor of message received callback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,8 +41,11 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <vectornav/Ins.h>
 
+
 ros::Publisher pubIMU, pubMag, pubGPS, pubOdom, pubTemp, pubPres, pubIns;
 ros::ServiceServer resetOdomSrv;
+
+XmlRpc::XmlRpcValue rpc_temp;
 
 // Include this header file to get access to VectorNav sensors.
 #include "vn/sensors.h"
@@ -57,9 +60,6 @@ using namespace vn::xplat;
 
 // Method declarations for future use.
 void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index);
-
-
-XmlRpc::XmlRpcValue rpc_temp;
 
 // Custom user data to pass to packet callback function
 struct UserData {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -310,6 +310,7 @@ void fill_imu_message(
         if (user_data->tf_ned_to_enu)
         {
             // If we want the orientation to be based on the reference label on the imu
+            tf2::Quaternion tf2_quat(q[0],q[1],q[2],q[3]);
             geometry_msgs::Quaternion quat_msg;
 
             if(user_data->frame_based_enu)
@@ -318,7 +319,6 @@ void fill_imu_message(
                 tf2::Quaternion q_rotate;
                 q_rotate.setRPY (M_PI, 0.0, M_PI/2);
                 // Apply the NED to ENU rotation such that the coordinate frame matches
-                tf2::Quaternion tf2_quat(q[0],q[1],q[2],q[3]);
                 tf2_quat = q_rotate*tf2_quat;
                 quat_msg = tf2::toMsg(tf2_quat);
 
@@ -511,11 +511,12 @@ void fill_odom_message(
             msgOdom.pose.pose.orientation.z = q[2];
             msgOdom.pose.pose.orientation.w = q[3];
         } else if(user_data->tf_ned_to_enu && user_data->frame_based_enu) {
-            // standard conversion from NED to ENU framevec3d initial_position;
+            // standard conversion from NED to ENU frame
+            tf2::Quaternion tf2_quat(q[0],q[1],q[2],q[3]);
+            // Create a rotation from NED -> ENU
             tf2::Quaternion q_rotate;
             q_rotate.setRPY (M_PI, 0.0, M_PI/2);
             // Apply the NED to ENU rotation such that the coordinate frame matches
-            tf2::Quaternion tf2_quat(q[0],q[1],q[2],q[3]);
             tf2_quat = q_rotate*tf2_quat;
             msgOdom.pose.pose.orientation = tf2::toMsg(tf2_quat);
         } else if(user_data->tf_ned_to_enu && !user_data->frame_based_enu) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,9 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <vectornav/Ins.h>
 
+ros::Publisher pubIMU, pubMag, pubGPS, pubOdom, pubTemp, pubPres, pubIns;
+ros::ServiceServer resetOdomSrv;
+
 // Include this header file to get access to VectorNav sensors.
 #include "vn/sensors.h"
 #include "vn/compositedata.h"
@@ -52,8 +55,9 @@ using namespace vn::sensors;
 using namespace vn::protocol::uart;
 using namespace vn::xplat;
 
-ros::Publisher pubIMU, pubMag, pubGPS, pubOdom, pubTemp, pubPres, pubIns;
-ros::ServiceServer resetOdomSrv;
+// Method declarations for future use.
+void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index);
+
 
 XmlRpc::XmlRpcValue rpc_temp;
 
@@ -77,9 +81,6 @@ struct UserData {
     boost::array<double, 9ul> angular_vel_covariance = { };
     boost::array<double, 9ul> orientation_covariance = { };
 };
-
-// Method declarations for future use.
-void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index);
 
 // Basic loop so we can initilize our covariance parameters above
 boost::array<double, 9ul> setCov(XmlRpc::XmlRpcValue rpc){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -397,32 +397,6 @@ void fill_mag_message(
     }
 }
 
-//Helper function to create temperature message
-void fill_temp_message(
-    sensor_msgs::Temperature &msgTemp, vn::sensors::CompositeData &cd, ros::Time &time, UserData *user_data)
-{
-    msgTemp.header.stamp = time;
-    msgTemp.header.frame_id = user_data->frame_id;
-    if (cd.hasTemperature())
-    {
-        float temp = cd.temperature();
-        msgTemp.temperature = temp;
-    }
-}
-
-//Helper function to create pressure message
-void fill_pres_message(
-    sensor_msgs::FluidPressure &msgPres, vn::sensors::CompositeData &cd, ros::Time &time, UserData *user_data)
-{
-    msgPres.header.stamp = time;
-    msgPres.header.frame_id = user_data->frame_id;
-    if (cd.hasPressure())
-    {
-        float pres = cd.pressure();
-        msgPres.fluid_pressure = pres;
-    }
-}
-
 //Helper function to create gps message
 void fill_gps_message(
     sensor_msgs::NavSatFix &msgGPS, vn::sensors::CompositeData &cd, ros::Time &time, UserData *user_data)
@@ -600,6 +574,33 @@ void fill_odom_message(
                 msgOdom.twist.covariance[(row + 3) * 6 + (col + 3)] = user_data->angular_vel_covariance[row * 3 + col];
             }
         }
+    }
+}
+
+
+//Helper function to create temperature message
+void fill_temp_message(
+    sensor_msgs::Temperature &msgTemp, vn::sensors::CompositeData &cd, ros::Time &time, UserData *user_data)
+{
+    msgTemp.header.stamp = time;
+    msgTemp.header.frame_id = user_data->frame_id;
+    if (cd.hasTemperature())
+    {
+        float temp = cd.temperature();
+        msgTemp.temperature = temp;
+    }
+}
+
+//Helper function to create pressure message
+void fill_pres_message(
+    sensor_msgs::FluidPressure &msgPres, vn::sensors::CompositeData &cd, ros::Time &time, UserData *user_data)
+{
+    msgPres.header.stamp = time;
+    msgPres.header.frame_id = user_data->frame_id;
+    if (cd.hasPressure())
+    {
+        float pres = cd.pressure();
+        msgPres.fluid_pressure = pres;
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -670,10 +670,10 @@ void fill_ins_message(
 //
 // Callback function to process data packet from sensor
 //
-void BinaryAsyncMessageReceived(void* user_data, Packet& p, size_t index)
+void BinaryAsyncMessageReceived(void* userData, Packet& p, size_t index)
 {
     vn::sensors::CompositeData cd = vn::sensors::CompositeData::parse(p);
-    //UserData* user_data = static_cast<UserData*>(userData);
+    UserData *user_data = static_cast<UserData*>(userData);
     ROS_INFO("async callback %d", user_data->initial_position_set);
 
     ros::Time time = ros::Time::now();


### PR DESCRIPTION
I restructured the callback in order to make it a bit more obvious which message is published at what point. Here a list of the changes:

* Move assignments to messages into individual functions (`fill_XXX_message`)
* Remove most of the global variables (not very C++) into the `UserData` structure that is passed around as a pointer now (both to the receive callback and the odom_reset service)
* Only publish data (any data) if someone subscribes to the topic.

@dawonn I tried to not touch any of the code if it was avoidable, so the functionality should still be the same. However this is quite a change, so I leave it up to you to decide if you think it makes sense to merge this here. I tested it as much as I can (including the odmetry service callback) and it all looks ok.

I feel the new structure makes it easier to understand the code, particularly the message received callback. Also now all topics are published at each callback whenever there is a subscriber, assuring they are at a constant rate.

Next I was planing on allowing a custom rate for the IMU message, which was the main reason I thought a restructure would make things easier.