### PR TITLE
add function to assure messages arrive at fixed time intervals

### DIFF
--- a/params/vn200.yaml
+++ b/params/vn200.yaml
@@ -7,7 +7,9 @@ serial_baud: 921600
 
 # Acceptable data rates in Hz: 1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200
 # Baud rate must be able to handle the data rate
-async_output_rate: 40
+async_output_rate: 200
+
+imu_output_rate: 200
 
 # Device IMU Rate as set by the manufacturer (800Hz unless specified otherwise)
 # This value is used to set the serial data packet rate

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
             GPSGROUP_NONE,
             ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
             INSGROUP_INSSTATUS
-            | INSGROUP_POSLLA
+            | INSGROUP_POSECEF
             | INSGROUP_VELBODY
             | INSGROUP_ACCELECEF
             | INSGROUP_VELNED


### PR DESCRIPTION
This will fix an issue I have been observing for a while now but had a hard time to figure out how to deal with it. Up to now when the driver was run at more than maybe 80Hz or so, then packages didn't arrive at well defined intervals. The packages will still be published at the right rate, but a few of them will have header.stamps really close in time, followed by a larger gap.

I talked to the guys over at vectornav and this was the solution we came up with to address it to some extent. I am not sure if they will be adding this to their driver (where it would be easier to implement), so I added a little hack here that does the same. This should also be achieved by using the command line and type either:


```
setserial /dev/<tty_name> low_latency
```

or

```
echo 1 > /sys/bus/usb-serial/devices/<tty_name>/latency_timer
```

However, I think the in program solution is more elegant. This will only affect operation on linux. I have not tested this anywhere else, and it should not enable the function on another system. The changes to the serial port will stay effective after the first call until the cable is unplugged.

I also made sure that output register 2 and 3 won't publish any data, when running this driver. Furthermore, I removed a line from the INSGROUP that the vectornav representative pointed out to be identical to COMMONGROUP_POSITION and thus not necessary.