### PR TITLE
Publish strides

### DIFF
--- a/params/vn100.yaml
+++ b/params/vn100.yaml
@@ -9,6 +9,14 @@ serial_baud: 115200
 # Baud rate must be able to handle the data rate
 async_output_rate: 40
 
+# Only publish every X package for a given topic. The actual publish rate will be
+# async_output_rate / *_stride. If set to 0, no message will be published on that topic.
+imu_stride: 1
+mag_stride: 1
+odom_stride: 1
+pres_stride: 1
+temp_stride: 1
+
 # Device IMU Rate as set by the manufacturer (800Hz unless specified otherwise)
 # This value is used to set the serial data packet rate
 fixed_imu_rate: 800

--- a/params/vn200.yaml
+++ b/params/vn200.yaml
@@ -7,13 +7,24 @@ serial_baud: 921600
 
 # Acceptable data rates in Hz: 1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200
 # Baud rate must be able to handle the data rate
-async_output_rate: 200
+async_output_rate: 40
 
-imu_output_rate: 200
+# Only publish every X package for a given topic. The actual publish rate will be
+# async_output_rate / *_stride. If set to 0, no message will be published on that topic.
+gps_stride: 1
+imu_stride: 1
+ins_stride: 1
+mag_stride: 1
+odom_stride: 1
+pres_stride: 1
+temp_stride: 1
 
 # Device IMU Rate as set by the manufacturer (800Hz unless specified otherwise)
 # This value is used to set the serial data packet rate
 fixed_imu_rate: 800
+
+# Frame id where pose of Odom message is specified (used only for Odom header.frame_id)
+map_frame_id: map
 
 # Frame id to publish data in
 frame_id: Vectornav

--- a/params/vn200.yaml
+++ b/params/vn200.yaml
@@ -7,7 +7,9 @@ serial_baud: 921600
 
 # Acceptable data rates in Hz: 1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200
 # Baud rate must be able to handle the data rate
-async_output_rate: 40
+async_output_rate: 200
+
+imu_output_rate: 200
 
 # Device IMU Rate as set by the manufacturer (800Hz unless specified otherwise)
 # This value is used to set the serial data packet rate

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,7 @@ int main(int argc, char *argv[])
             GPSGROUP_NONE,
             ATTITUDEGROUP_YPRU, //<-- returning yaw pitch roll uncertainties
             INSGROUP_INSSTATUS
-            | INSGROUP_POSLLA
+            | INSGROUP_POSECEF
             | INSGROUP_VELBODY
             | INSGROUP_ACCELECEF
             | INSGROUP_VELNED


### PR DESCRIPTION
This will allow to configure (to some extend) the publish rate of different topics. This is achieved through individual stride parameters that define how many data packages will be skipped before a message is published on a given topic.

I have tested this with a VN200, all with different strides and it works fine.