### PR TITLE
change %d to %zu format specifier to avoid warning messages

### DIFF
--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -365,7 +365,7 @@ private:
       break;
 
     default:
-      RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %d; expected 1, 3, or 9",
+      RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %zu; expected 1, 3, or 9",
                    param_name.c_str(), length);
     }
   }


### PR DESCRIPTION
On Ubuntu 20.04 on amd x86_64 I get the below warning message. This PR fixes the warning message.
The type of variable "length" is the type returned by std::vector<>.size(), which is std::size_t. The appropriate format specifier should be "%zu", as per [this stack exchange](https://stackoverflow.com/questions/940087/whats-the-correct-way-to-use-printf-to-print-a-size-t)

```
vectornav/src/vn_sensor_msgs.cc:17:
vn_sensor_msgs.cc: In member function ‘void VnSensorMsgs::fill_covariance_from_param(std::string, std::array<double, 9>&) const’:
vn_sensor_msgs.cc:368:34: warning: format ‘%d’ expects argument of type ‘int’, but argument 6 has type ‘long unsigned int’ [-Wformat=]
  368 |       RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %d; expected 1, 3, or 9",
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  369 |                    param_name.c_str(), length);
      |                                        ~~~~~~
      |                                        |
      |                                        long unsigned int
vn_sensor_msgs.cc:368:61: note: format string is defined here
  368 |       RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %d; expected 1, 3, or 9",
      |                                                            ~^
      |                                                             |
      |                                                             int
      |                                                            %ld

```