### PR TITLE
don't bomb out if no GPS is present (VN100)

### DIFF
--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -348,28 +348,32 @@ private:
     configBO3.gps2Field = (vn::protocol::uart::GpsGroup)get_parameter("BO3.gps2Field").as_int();
     vs_.writeBinaryOutput3(configBO3);
 
-    // GPS Configuration
-    // 8.2.1
-    auto gps_config = vs_.readGpsConfiguration();
-    RCLCPP_INFO(get_logger(), "GPS Mode       : %d", gps_config.mode);
-    RCLCPP_INFO(get_logger(), "GPS PPS Source : %d", gps_config.ppsSource);
-    /// TODO(Dereck): VnSensor::readGpsConfiguration() missing fields
+    try {
+      // GPS Configuration
+      // 8.2.1
+      auto gps_config = vs_.readGpsConfiguration();
+      RCLCPP_INFO(get_logger(), "GPS Mode       : %d", gps_config.mode);
+      RCLCPP_INFO(get_logger(), "GPS PPS Source : %d", gps_config.ppsSource);
+      /// TODO(Dereck): VnSensor::readGpsConfiguration() missing fields
 
-    // GPS Offset
-    // 8.2.2
-    auto gps_offset = vs_.readGpsAntennaOffset();
-    RCLCPP_INFO(get_logger(), "GPS Offset     : (%f, %f, %f)", gps_offset[0], gps_offset[1],
-                gps_offset[2]);
+      // GPS Offset
+      // 8.2.2
+      auto gps_offset = vs_.readGpsAntennaOffset();
+      RCLCPP_INFO(get_logger(), "GPS Offset     : (%f, %f, %f)", gps_offset[0], gps_offset[1],
+                  gps_offset[2]);
 
-    // GPS Compass Baseline
-    // 8.2.3
-    // According to dawonn, readGpsCompassBaseline is likely only available 
-    // on the VN-300
-    if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
-      auto gps_baseline = vs_.readGpsCompassBaseline();
-      RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
-        gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
-        gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+      // GPS Compass Baseline
+      // 8.2.3
+      // According to dawonn, readGpsCompassBaseline is likely only available
+      // on the VN-300
+      if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
+        auto gps_baseline = vs_.readGpsCompassBaseline();
+        RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
+          gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
+          gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+      }
+    } catch (const vn::sensors::sensor_error &e) {
+      RCLCPP_WARN(get_logger(), "GPS initialization error (does your sensor have one?)");
     }
     // Register Binary Data Callback
     vs_.registerAsyncPacketReceivedHandler(this, Vectornav::AsyncPacketReceivedHandler);

--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -365,7 +365,7 @@ private:
       break;
 
     default:
-      RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %d; expected 1, 3, or 9",
+      RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %zu; expected 1, 3, or 9",
                    param_name.c_str(), length);
     }
   }


### PR DESCRIPTION
When running with the VN100 I got the following error:
```
[vectornav-1] [INFO] [1639963004.019886469] [vectornav]: Connected to /dev/ttyUSB0 @ 921600 baud
[vectornav-1] [INFO] [1639963004.020096902] [vectornav]: Model: VN-100T-CR
[vectornav-1] [INFO] [1639963004.020133708] [vectornav]: Firmware Version: 2.1.0.0
[vectornav-1] [INFO] [1639963004.020157454] [vectornav]: Hardware Version : 7
[vectornav-1] [INFO] [1639963004.020181689] [vectornav]: Serial Number : 100056785
[vectornav-1] [INFO] [1639963004.020204946] [vectornav]: User Tag : ""
[vectornav-1] [ERROR] [1639963004.092948204] [vectornav]: SensorError: 8
[vectornav-1] terminate called after throwing an instance of 'vn::sensors::sensor_error'
[vectornav-1]   what():  received sensor error 'InvalidRegister'
```
The "SensorError: 8" is being thrown where the GPS is intialized (the VN100 has no GPS). Since I couldn't find a way to test for the presence of a GPS I decided to handle the exception and log  a warning. This PR allows me to run the VN100 under ROS2.

I really appreciate you guys writing a ROS2 driver for the VectorNavs.