### PR TITLE
Fix incorrect reading of InsStatus field

### DIFF
--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -818,7 +818,7 @@ private:
     // Group Fields
     msg.group_fields = groupFields;
 
-    if (compositeData.hasVpeStatus()) {
+    if (compositeData.hasInsStatus()) {
       msg.insstatus = toMsg(compositeData.insStatus());
     }
 


### PR DESCRIPTION
InsStatus field was not being populated since we were checking if VpeStatus field was present instead of InsStatus field.