### PR TITLE
adjust ROS header time stamp according to sensor time

### DIFF
--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -348,28 +348,32 @@ private:
     configBO3.gps2Field = (vn::protocol::uart::GpsGroup)get_parameter("BO3.gps2Field").as_int();
     vs_.writeBinaryOutput3(configBO3);
 
-    // GPS Configuration
-    // 8.2.1
-    auto gps_config = vs_.readGpsConfiguration();
-    RCLCPP_INFO(get_logger(), "GPS Mode       : %d", gps_config.mode);
-    RCLCPP_INFO(get_logger(), "GPS PPS Source : %d", gps_config.ppsSource);
-    /// TODO(Dereck): VnSensor::readGpsConfiguration() missing fields
+    try {
+      // GPS Configuration
+      // 8.2.1
+      auto gps_config = vs_.readGpsConfiguration();
+      RCLCPP_INFO(get_logger(), "GPS Mode       : %d", gps_config.mode);
+      RCLCPP_INFO(get_logger(), "GPS PPS Source : %d", gps_config.ppsSource);
+      /// TODO(Dereck): VnSensor::readGpsConfiguration() missing fields
 
-    // GPS Offset
-    // 8.2.2
-    auto gps_offset = vs_.readGpsAntennaOffset();
-    RCLCPP_INFO(get_logger(), "GPS Offset     : (%f, %f, %f)", gps_offset[0], gps_offset[1],
-                gps_offset[2]);
+      // GPS Offset
+      // 8.2.2
+      auto gps_offset = vs_.readGpsAntennaOffset();
+      RCLCPP_INFO(get_logger(), "GPS Offset     : (%f, %f, %f)", gps_offset[0], gps_offset[1],
+                  gps_offset[2]);
 
-    // GPS Compass Baseline
-    // 8.2.3
-    // According to dawonn, readGpsCompassBaseline is likely only available 
-    // on the VN-300
-    if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
-      auto gps_baseline = vs_.readGpsCompassBaseline();
-      RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
-        gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
-        gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+      // GPS Compass Baseline
+      // 8.2.3
+      // According to dawonn, readGpsCompassBaseline is likely only available
+      // on the VN-300
+      if (vs_.determineDeviceFamily() == vn::sensors::VnSensor::VnSensor_Family_Vn300) {
+        auto gps_baseline = vs_.readGpsCompassBaseline();
+        RCLCPP_INFO(get_logger(), "GPS Baseline     : (%f, %f, %f), (%f, %f, %f)",
+          gps_baseline.position[0], gps_baseline.position[1], gps_baseline.position[2],
+          gps_baseline.uncertainty[0], gps_baseline.uncertainty[1], gps_baseline.uncertainty[2]);
+      }
+    } catch (const vn::sensors::sensor_error &e) {
+      RCLCPP_WARN(get_logger(), "GPS initialization error (does your sensor have one?)");
     }
     // Register Binary Data Callback
     vs_.registerAsyncPacketReceivedHandler(this, Vectornav::AsyncPacketReceivedHandler);

--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -365,7 +365,7 @@ private:
       break;
 
     default:
-      RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %d; expected 1, 3, or 9",
+      RCLCPP_ERROR(get_logger(), "Parameter '%s' length is %zu; expected 1, 3, or 9",
                    param_name.c_str(), length);
     }
   }


### PR DESCRIPTION
Fix for issue #87

In the current implementation the header.stamp time is generated by a call to the ROS node's now() method. This means the time stamp is generated when the callback from the vectornav driver happens. However there seems to be no guarantee that the callback happens right away when the data arrives at the driver level. This results in poor header time stamp quality.

This PR adjust the time stamps by computing an exponential moving average of the difference between ROS system and sensor provided time, then using that difference to compute the ROS time stamps from the sensor time.

Attached is a graph of  header time stamps (count is along x axis, time stamp value in seconds is along y axis) that shows the improvement in quality.
![vn100_timestamps](https://user-images.githubusercontent.com/6206826/147516341-9d48a148-8b41-436a-8f02-627dc42a2331.png)
