### PR TITLE
added clang style file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,20 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+BraceWrapping:
+  AfterClass: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+BreakBeforeBraces: Custom
+ColumnLimit: 100
+ConstructorInitializerIndentWidth: 0
+ContinuationIndentWidth: 2
+DerivePointerAlignment: false
+PointerAlignment: Middle
+ReflowComments: false
+...
+


### PR DESCRIPTION
add clang style file that should yield ROS style guide formatting

This style file should be applied to all c++ files other than the ones in the vnproglib directory.

Then in a separate pull request the files should be reformatted without any changes to the logic. Before that happens though, please consider merging existing PRs (in particular #88) first.

This PR closes issue #89 

