### PR TITLE
fixed bug in time stamp adjustment which actually enabled it

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,13 +745,13 @@ static ros::Time get_time_stamp(
     if (!cd.hasTimeStartup() || !user_data->adjust_ros_timestamp) {
         return (ros_time); // don't adjust timestamp
     }
-    const uint64_t sensor_time = cd.timeStartup() * 1e-9; // time in seconds
+    const double sensor_time = cd.timeStartup() * 1e-9; // time in seconds
     if (user_data->average_time_difference == 0) { // first call
         user_data->ros_start_time = ros_time;
-        user_data->average_time_difference = static_cast<double>(sensor_time);
+        user_data->average_time_difference = static_cast<double>(-sensor_time);
     }
     // difference between node startup and current ROS time
-    const double ros_dt = ros_time.toSec() - user_data->ros_start_time.toSec();
+    const double ros_dt = (ros_time - user_data->ros_start_time).toSec();
     // difference between elapsed ROS time and time since sensor startup
     const double dt = ros_dt - sensor_time;
     // compute exponential moving average
@@ -760,7 +760,8 @@ static ros::Time get_time_stamp(
         user_data->average_time_difference * (1.0 - alpha) + alpha * dt;
 
     // adjust sensor time by average difference to ROS time
-    const ros::Time adj_time = user_data->ros_start_time + ros::Duration(dt + sensor_time);
+    const ros::Time adj_time = user_data->ros_start_time + ros::Duration(
+      user_data->average_time_difference + sensor_time);
     return (adj_time);
 }
 


### PR DESCRIPTION
fixed bug with ROS1 timestamp adjustment as discussed in issue #94
Two bugs conspired to effectively switch off the entire time stamp adjustment. This PR fixes both bugs.
The below graph shows the time deltas (dt) between subsequent ROS header time stamps with adjustment (red) and without adjustment (green).

![adjusted_vs_unadjusted](https://user-images.githubusercontent.com/6206826/149434441-c3ca88b0-2f27-4275-945b-6c7efa7dab3f.png)
