### PR TITLE
add separate imu rate

### DIFF
--- a/params/vn200.yaml
+++ b/params/vn200.yaml
@@ -7,9 +7,11 @@ serial_baud: 921600
 
 # Acceptable data rates in Hz: 1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200
 # Baud rate must be able to handle the data rate
-async_output_rate: 200
+async_output_rate: 40
 
-imu_output_rate: 200
+# Acceptable imu rates in Hz: 1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200
+# If not defined, will be equal to async_output_rate
+imu_output_rate: 40
 
 # Device IMU Rate as set by the manufacturer (800Hz unless specified otherwise)
 # This value is used to set the serial data packet rate
@@ -41,5 +43,5 @@ angular_vel_covariance: [0.01,  0.0,   0.0,
 
 # Orientation covariance overwritten in driver, this is included just as an extra
 orientation_covariance: [0.01,  0.0,   0.0,
-                            0.0,   0.01,  0.0,
-                            0.0,   0.0,   0.01]
+                         0.0,   0.01,  0.0,
+                         0.0,   0.0,   0.01]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,9 +292,7 @@ int main(int argc, char *argv[])
     ROS_ASSERT_MSG(
         package_rate,
         "imu_output_rate (%d) or async_output_rate (%d) is not in 1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200 Hz",
-        imu_output_rate,
-        async_output_rate
-    );
+        imu_output_rate, async_output_rate);
     user_data.imu_stride = package_rate / imu_output_rate;
     user_data.output_stride = package_rate / async_output_rate;
     ROS_INFO("Package Receive Rate: %d Hz", package_rate);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
     int package_rate = 0; 
     for(int allowed_rate: {1, 2, 4, 5, 10, 20, 25, 40, 50, 100, 200, 0}){
         package_rate = allowed_rate;
-        if (package_rate % async_output_rate == 0 && package_rate % imu_output_rate == 0) break;
+        if ((package_rate % async_output_rate) == 0 && (package_rate % imu_output_rate) == 0) break;
     }
     ROS_ASSERT_MSG(
         package_rate,


### PR DESCRIPTION
This is a follow up on https://github.com/dawonn/vectornav/pull/83. It will only add a single additional parameter, the imu publish rate, that now can be configured independently of the other topics.

This will also add some checks to make sure the device can actually deliver on the request data rate.

Overall the changes are quite limited, and it is entirely backwards compatible in that if the parameter `imu_output_rate` is not defined it will use the same as the `async_output_rate`.