### PR TITLE
avoid segfault on exit

### DIFF
--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -177,6 +177,15 @@ public:
     }
   }
 
+  ~Vectornav()
+  {
+    if (reconnect_timer_) {
+      reconnect_timer_->cancel();
+      reconnect_timer_.reset();
+    }
+    vs_.disconnect();
+  }
+
 private:
   /**
    * set serial port to low latency async to avoid bunching up of callbacks


### PR DESCRIPTION
Currently the ROS2 driver segfaults when it receives SIG_INT (ctrl-C). This PR fixes that.
