### PR TITLE
also unregister packet handlers, may fix remaining segfaults on ctrl-C

### DIFF
--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -183,6 +183,8 @@ public:
       reconnect_timer_->cancel();
       reconnect_timer_.reset();
     }
+    vs_.unregisterErrorPacketReceivedHandler();
+    vs_.unregisterAsyncPacketReceivedHandler();
     vs_.disconnect();
   }
 


### PR DESCRIPTION
Got another segfault on ctrl-C, presumably because of two callbacks still registered. This is related to PR #105 