### PR TITLE
Raw ned enu

### DIFF
--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -180,8 +180,16 @@ private:
       q_ned2enu.setRPY(M_PI, 0.0, M_PI / 2);
       msg.orientation = toMsg(q_ned2enu * q);
 
-      msg.angular_velocity = msg_in->angularrate;
-      msg.linear_acceleration = msg_in->accel;
+      // NED to ENU conversion
+      // swap x and y and negate z
+      msg.angular_velocity.x = msg_in->angularrate.y;
+      msg.angular_velocity.y = msg_in->angularrate.x;
+      msg.angular_velocity.z = -msg_in->angularrate.z;
+
+      msg.linear_acceleration.x = msg_in->accel.y;
+      msg.linear_acceleration.y = msg_in->accel.x;
+      msg.linear_acceleration.z = -msg_in->accel.z;
+
 
       fill_covariance_from_param("orientation_covariance", msg.orientation_covariance);
       fill_covariance_from_param("angular_velocity_covariance", msg.angular_velocity_covariance);
@@ -195,8 +203,16 @@ private:
     {
       sensor_msgs::msg::Imu msg;
       msg.header = msg_in->header;
-      msg.angular_velocity = msg_in->imu_rate;
-      msg.linear_acceleration = msg_in->imu_accel;
+
+      // NED to ENU conversion
+      // swap x and y and negate z
+      msg.angular_velocity.x = msg_in->imu_rate.y;
+      msg.angular_velocity.y = msg_in->imu_rate.x;
+      msg.angular_velocity.z = -msg_in->imu_rate.z;
+
+      msg.linear_acceleration.x = msg_in->imu_accel.y;
+      msg.linear_acceleration.y = msg_in->imu_accel.x;
+      msg.linear_acceleration.z = -msg_in->imu_accel.z;
 
       fill_covariance_from_param("angular_velocity_covariance", msg.angular_velocity_covariance);
       fill_covariance_from_param(

--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -21,7 +21,7 @@
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
 #include "sensor_msgs/msg/temperature.hpp"
 #include "sensor_msgs/msg/time_reference.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp
 #include "vectornav_msgs/msg/attitude_group.hpp"
 #include "vectornav_msgs/msg/common_group.hpp"
 #include "vectornav_msgs/msg/gps_group.hpp"
@@ -189,7 +189,6 @@ private:
       msg.linear_acceleration.x = msg_in->accel.y;
       msg.linear_acceleration.y = msg_in->accel.x;
       msg.linear_acceleration.z = -msg_in->accel.z;
-
 
       fill_covariance_from_param("orientation_covariance", msg.orientation_covariance);
       fill_covariance_from_param("angular_velocity_covariance", msg.angular_velocity_covariance);


### PR DESCRIPTION
This PR adds conversion for the raw IMU readings (gyro and accelerometer) from the NED frame the sensor uses to the ROS standard ENU. 

The conversion is already done for the orientation just not the raw sensor readings. This is useful for us as we have our own fusion framework that makes use of just the raw readings. I thought some other people might have a similar use case so I thought I'd share this quick PR.

Also I've updated the tf2_geometry_msgs header as the current version is obsolete.