### PR TITLE
Make ENU conversion a parameter

### DIFF
--- a/vectornav/config/vectornav.yaml
+++ b/vectornav/config/vectornav.yaml
@@ -61,6 +61,7 @@ vectornav:
 
 vn_sensor_msgs:
   ros__parameters:
+    use_enu: true
     orientation_covariance: [0.01,  0.0,   0.0,
                             0.0,   0.01,  0.0,
                             0.0,   0.0,   0.01]

--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -212,15 +212,20 @@ private:
       sensor_msgs::msg::Imu msg;
       msg.header = msg_in->header;
 
-      // NED to ENU conversion
-      // swap x and y and negate z
-      msg.angular_velocity.x = msg_in->imu_rate.y;
-      msg.angular_velocity.y = msg_in->imu_rate.x;
-      msg.angular_velocity.z = -msg_in->imu_rate.z;
+      if(use_enu) {
+        // NED to ENU conversion
+        // swap x and y and negate z
+        msg.angular_velocity.x = msg_in->angularrate.y;
+        msg.angular_velocity.y = msg_in->angularrate.x;
+        msg.angular_velocity.z = -msg_in->angularrate.z;
 
-      msg.linear_acceleration.x = msg_in->imu_accel.y;
-      msg.linear_acceleration.y = msg_in->imu_accel.x;
-      msg.linear_acceleration.z = -msg_in->imu_accel.z;
+        msg.linear_acceleration.x = msg_in->accel.y;
+        msg.linear_acceleration.y = msg_in->accel.x;
+        msg.linear_acceleration.z = -msg_in->accel.z;
+      } else {
+        msg.angular_velocity = msg_in->angularrate;
+        msg.linear_acceleration = msg_in->accel;
+      }
 
       fill_covariance_from_param("angular_velocity_covariance", msg.angular_velocity_covariance);
       fill_covariance_from_param(


### PR DESCRIPTION
Hi!
This PR makes the recently added ENU conversion a feature that can be enabled or disabled by setting a parameter on the vn_sensor_msgs node. This allows users to choose between using ENU, which obeys the ROS standard, and NED, which obeys the coordinate frames printed on the IMUs. The parameter in question is a boolean value called use_enu; if its value is true, then raw values from the IMU are converted to ENU frame before being published. Otherwise, the values are left alone and published in the NED frame. The parameter is only read on driver startup to prevent users from flipping coordinate frames in runtime.

I have left the default value of the parameter as true (ENU) because that is the current driver behavior. However, it makes more sense for the default to be false (NED) because it obeys the coordinate frame printed on VectorNavs IMUs. I will leave this up to your discretion.

Thanks!