### PR TITLE
Fix crash after disconnect

### DIFF
--- a/vectornav/vnproglib-1.2.0.0/cpp/src/sensors.cpp
+++ b/vectornav/vnproglib-1.2.0.0/cpp/src/sensors.cpp
@@ -692,9 +692,8 @@ void VnSensor::disconnect()
 	if (_pi->SimplePortIsOurs)
 	{
 		delete _pi->port;
-
-		_pi->port = NULL;
 	}
+	_pi->port = NULL;
 
 	if (_pi->pSerialPort != NULL)
 	{


### PR DESCRIPTION
This PR fixes a seg fault that was occurring when the sensor connection is lost and then the connection can't be established again. 

We are currently having some comms issues which we have yet to fully resolve. But this crash was identified and fixed in the process.

Basically, the issue is that the `_pi->port` is set to the address of the `_pi->pSerialPort`. But in the destructor, `_pi->port` is not reset to Null.

Testing has been carried out with our VN-300 and the crash no longer occurs when comms is lost.