### PR TITLE
Fix INS status message encoding

### DIFF
--- a/vectornav/src/vectornav.cc
+++ b/vectornav/src/vectornav.cc
@@ -1436,11 +1436,10 @@ private:
     lhs.gps_fix = rhs & vn::protocol::uart::InsStatus::INSSTATUS_GPS_FIX;
     lhs.time_error = rhs & vn::protocol::uart::InsStatus::INSSTATUS_TIME_ERROR;
     lhs.imu_error = rhs & vn::protocol::uart::InsStatus::INSSTATUS_IMU_ERROR;
-    lhs.time_error = rhs & vn::protocol::uart::InsStatus::INSSTATUS_GPS_FIX;
     lhs.mag_pres_error = rhs & vn::protocol::uart::InsStatus::INSSTATUS_MAG_PRES_ERROR;
     lhs.gps_error = rhs & vn::protocol::uart::InsStatus::INSSTATUS_GPS_ERROR;
-    lhs.gps_heading_ins = rhs & 0x0080;
-    lhs.gps_compass = rhs & 0x0100;
+    lhs.gps_heading_ins = rhs & 0x0100;
+    lhs.gps_compass = rhs & 0x0200;
     return lhs;
   }
 


### PR DESCRIPTION
This PR fixes an error with the INS status message encoding. The bit masks now match the bit offsets specified in the manual.

![INS Status](https://github.com/dawonn/vectornav/assets/136551598/029fda12-d717-4da3-9515-746c2435f8a2)

I've tested this on our VN-300 and the `gps_compass` and `gps_heading_ins` fields are now reporting correctly.

Note, I don't know what the `time_error` field is. It is not specified in the manual. The bit offset at this value is `Reserved`