### PR TITLE
fix NED ENU conversion

### DIFF
--- a/vectornav/CMakeLists.txt
+++ b/vectornav/CMakeLists.txt
@@ -26,6 +26,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(vectornav_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 # vncxx
 add_subdirectory(vnproglib-1.2.0.0/cpp)
@@ -44,6 +45,7 @@ target_link_libraries(${PROJECT_NAME} vncxx ${PROJECT_NAME}_lib)
 
 # vn_sensor_msgs library (with composable node)
 add_library(vn_sensor_msgs_lib SHARED src/vn_sensor_msgs.cc)
+target_include_directories(vn_sensor_msgs_lib PUBLIC ${EIGEN3_INCLUDE_DIRS})
 ament_target_dependencies(vn_sensor_msgs_lib
   rclcpp rclcpp_components sensor_msgs vectornav_msgs tf2_geometry_msgs)
 rclcpp_components_register_nodes(vn_sensor_msgs_lib "vectornav::VnSensorMsgs")

--- a/vectornav/CMakeLists.txt
+++ b/vectornav/CMakeLists.txt
@@ -26,7 +26,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(vectornav_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(Eigen3 REQUIRED)
 
 # vncxx
 add_subdirectory(vnproglib-1.2.0.0/cpp)
@@ -45,7 +44,6 @@ target_link_libraries(${PROJECT_NAME} vncxx ${PROJECT_NAME}_lib)
 
 # vn_sensor_msgs library (with composable node)
 add_library(vn_sensor_msgs_lib SHARED src/vn_sensor_msgs.cc)
-target_include_directories(vn_sensor_msgs_lib PUBLIC ${EIGEN3_INCLUDE_DIRS})
 ament_target_dependencies(vn_sensor_msgs_lib
   rclcpp rclcpp_components sensor_msgs vectornav_msgs tf2_geometry_msgs)
 rclcpp_components_register_nodes(vn_sensor_msgs_lib "vectornav::VnSensorMsgs")

--- a/vectornav/config/vectornav.yaml
+++ b/vectornav/config/vectornav.yaml
@@ -61,7 +61,7 @@ vectornav:
 
 vn_sensor_msgs:
   ros__parameters:
-    use_enu: true
+    use_enu: true  # this will convert from Forward-Right-Down body axes in NED to Right-Forward-Up body axes in ENU
     orientation_covariance: [0.01,  0.0,   0.0,
                             0.0,   0.01,  0.0,
                             0.0,   0.0,   0.01]

--- a/vectornav/src/vn_sensor_msgs.cc
+++ b/vectornav/src/vn_sensor_msgs.cc
@@ -15,6 +15,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <string>
+#include <Eigen/Dense>
 
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
@@ -117,9 +118,13 @@ static void convert_to_enu(
     msg_out.linear_acceleration.y = msg_in->imu_accel.x;
     msg_out.linear_acceleration.z = -msg_in->imu_accel.z;
   }
-
-  msg_out.orientation = msg_in->quaternion;
-  msg_out.orientation.z = -msg_in->quaternion.z;
+  Eigen::AngleAxisd flip(M_PI, Eigen::Vector3d(1, 1, 0).normalized());
+  Eigen::Quaterniond q(msg_in->quaternion.w, msg_in->quaternion.x, msg_in->quaternion.y, msg_in->quaternion.z);
+  q = flip * q * flip;
+  msg_out.orientation.w = q.w();
+  msg_out.orientation.x = q.x();
+  msg_out.orientation.y = q.y();
+  msg_out.orientation.z = q.z();
 }
 
 /** Convert VN common group data to ROS2 standard message types


### PR DESCRIPTION
The NED to ENU conversion flips the axes by 180 degrees around an axis that is between the x & y axes.

This was correctly implemented for the angular rate & acceleration, but not the quaternion of the estimated attitude.

This PR fixes the quaternion transformation.